### PR TITLE
Update GitHub Action

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -28,7 +28,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build and export Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: false

--- a/.github/workflows/process_wikipedia.yml
+++ b/.github/workflows/process_wikipedia.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true


### PR DESCRIPTION
This pull request updates the Docker build action version in two GitHub workflow files to ensure compatibility with the latest features and bug fixes.

GitHub workflow updates:

* [`.github/workflows/deploy-gcp.yml`](diffhunk://#diff-57ed3056e7a373d410a7264b760a8041bc157def448e2e468276b2f9d3b6ba79L31-R31): Updated the `docker/build-push-action` from version `v5` to `v6` in the "Build and export Docker image" step.
* [`.github/workflows/process_wikipedia.yml`](diffhunk://#diff-4f3fb35e1edfbc0f687b89f05a70ed0c38b98383358fc12548f86d7dc5ff6d4aL92-R92): Updated the `docker/build-push-action` from version `v5` to `v6` in the "Build and push Docker image" step.