### PR TITLE
Remove chunk options from wikipedia processing

### DIFF
--- a/nyc_landmarks/wikipedia/processor.py
+++ b/nyc_landmarks/wikipedia/processor.py
@@ -635,8 +635,6 @@ class WikipediaProcessor:
     def process_landmark_wikipedia(
         self,
         landmark_id: str,
-        chunk_size: int = 1000,
-        chunk_overlap: int = 200,
         delete_existing: bool = False,
     ) -> Tuple[bool, int, int]:
         """
@@ -644,8 +642,6 @@ class WikipediaProcessor:
 
         Args:
             landmark_id: ID of the landmark to process
-            chunk_size: Target size of each chunk in characters
-            chunk_overlap: Number of characters to overlap between chunks
             delete_existing: Whether to delete existing vectors for the landmark
 
         Returns:

--- a/scripts/ci/process_wikipedia_articles.py
+++ b/scripts/ci/process_wikipedia_articles.py
@@ -36,8 +36,6 @@ logger = get_logger(__name__)
 
 def process_landmarks_sequential(
     landmarks: List[str],
-    chunk_size: int,
-    chunk_overlap: int,
     delete_existing: bool,
 ) -> Dict[str, Any]:
     """
@@ -45,8 +43,6 @@ def process_landmarks_sequential(
 
     Args:
         landmarks: List of landmark IDs to process
-        chunk_size: Target size of each chunk in characters
-        chunk_overlap: Number of characters to overlap between chunks
         delete_existing: Whether to delete existing vectors for landmarks
 
     Returns:
@@ -61,7 +57,7 @@ def process_landmarks_sequential(
         try:
             success, articles_processed, chunks_embedded = (
                 processor.process_landmark_wikipedia(
-                    landmark_id, chunk_size, chunk_overlap, delete_existing
+                    landmark_id, delete_existing=delete_existing
                 )
             )
             results[landmark_id] = {
@@ -104,8 +100,6 @@ def process_landmarks_sequential(
 
 def process_landmarks_parallel(
     landmarks: List[str],
-    chunk_size: int,
-    chunk_overlap: int,
     delete_existing: bool,
     workers: int,
 ) -> Dict[str, Any]:
@@ -114,8 +108,6 @@ def process_landmarks_parallel(
 
     Args:
         landmarks: List of landmark IDs to process
-        chunk_size: Target size of each chunk in characters
-        chunk_overlap: Number of characters to overlap between chunks
         delete_existing: Whether to delete existing vectors for landmarks
         workers: Number of parallel workers
 
@@ -131,7 +123,7 @@ def process_landmarks_parallel(
         processor = WikipediaProcessor()
         success, articles_processed, chunks_embedded = (
             processor.process_landmark_wikipedia(
-                landmark_id, chunk_size, chunk_overlap, delete_existing
+                landmark_id, delete_existing=delete_existing
             )
         )
         return landmark_id, success, articles_processed, chunks_embedded
@@ -191,18 +183,6 @@ def parse_arguments() -> argparse.Namespace:
         "--landmark-ids",
         type=str,
         help="Comma-separated list of landmark IDs to process",
-    )
-    parser.add_argument(
-        "--chunk-size",
-        type=int,
-        default=1000,
-        help="Target size of each chunk in characters",
-    )
-    parser.add_argument(
-        "--chunk-overlap",
-        type=int,
-        default=200,
-        help="Number of characters to overlap between chunks",
     )
     parser.add_argument(
         "--parallel",
@@ -272,8 +252,6 @@ def setup_logging(verbose: bool) -> None:
 
 def process_landmarks(
     landmarks: List[str],
-    chunk_size: int,
-    chunk_overlap: int,
     delete_existing: bool,
     use_parallel: bool,
     workers: int,
@@ -284,12 +262,12 @@ def process_landmarks(
             f"Processing {len(landmarks)} landmarks in parallel with {workers} workers"
         )
         return process_landmarks_parallel(
-            landmarks, chunk_size, chunk_overlap, delete_existing, workers
+            landmarks, delete_existing, workers
         )
     else:
         logger.info(f"Processing {len(landmarks)} landmarks sequentially")
         return process_landmarks_sequential(
-            landmarks, chunk_size, chunk_overlap, delete_existing
+            landmarks, delete_existing
         )
 
 
@@ -311,8 +289,6 @@ def main() -> None:
     start_time = time.time()
     results = process_landmarks(
         landmarks_to_process,
-        args.chunk_size,
-        args.chunk_overlap,
         args.delete_existing,
         args.parallel,
         args.workers,

--- a/tests/unit/test_wikipedia_processing_fix.py
+++ b/tests/unit/test_wikipedia_processing_fix.py
@@ -47,10 +47,8 @@ class TestWikipediaProcessingFix(unittest.TestCase):
         mock_fetch.return_value = []
 
         # Process the landmark
-        success, articles_processed, chunks_embedded = (
-            processor.process_landmark_wikipedia(
-                "LP-12345", chunk_size=1000, chunk_overlap=200, delete_existing=False
-            )
+        success, articles_processed, chunks_embedded = processor.process_landmark_wikipedia(
+            "LP-12345", delete_existing=False
         )
 
         # Verify that no articles found is treated as success, not failure
@@ -94,10 +92,8 @@ class TestWikipediaProcessingFix(unittest.TestCase):
         mock_process.return_value = ([], 0)
 
         # Process the landmark
-        success, articles_processed, chunks_embedded = (
-            processor.process_landmark_wikipedia(
-                "LP-12345", chunk_size=1000, chunk_overlap=200, delete_existing=False
-            )
+        success, articles_processed, chunks_embedded = processor.process_landmark_wikipedia(
+            "LP-12345", delete_existing=False
         )
 
         # Verify that articles found but processing failed is treated as failure
@@ -151,10 +147,8 @@ class TestWikipediaProcessingFix(unittest.TestCase):
         mock_store.return_value = 3  # 3 chunks embedded
 
         # Process the landmark
-        success, articles_processed, chunks_embedded = (
-            processor.process_landmark_wikipedia(
-                "LP-12345", chunk_size=1000, chunk_overlap=200, delete_existing=False
-            )
+        success, articles_processed, chunks_embedded = processor.process_landmark_wikipedia(
+            "LP-12345", delete_existing=False
         )
 
         # Verify successful processing


### PR DESCRIPTION
## Summary
- drop chunk size CLI options from Wikipedia article processing script
- update WikipediaProcessor API to remove unused chunk arguments
- fix tests to use new signature

## Testing
- `pytest -q` *(fails: missing API keys and external services)*

------
https://chatgpt.com/codex/tasks/task_e_6843754aa3c8832faba8dc68a72a6c61