### PR TITLE
Handle zero articles consistently in parallel processing

### DIFF
--- a/scripts/ci/process_wikipedia_articles.py
+++ b/scripts/ci/process_wikipedia_articles.py
@@ -180,8 +180,9 @@ def process_landmarks_parallel(
                     "chunks_embedded": chunks_embedded,
                 }
 
-                # Track landmarks with no articles separately
-                if not success and articles_processed == 0:
+                # Track landmarks that had no articles processed
+                # regardless of whether processing succeeded or failed
+                if articles_processed == 0:
                     skipped_landmarks.add(landmark_id)
 
             except Exception as e:


### PR DESCRIPTION
This pull request updates the handling of landmarks with zero articles processed in the Wikipedia processing script and adds corresponding test cases to ensure the behavior is correctly implemented and verified.

### Updates to landmark processing logic:
* Modified the condition in `process_single_landmark` to track landmarks with zero articles processed as skipped, regardless of the success or failure of processing. (`scripts/ci/process_wikipedia_articles.py`, [scripts/ci/process_wikipedia_articles.pyL183-R185](diffhunk://#diff-79b6896dfc7b36e103e6e8d7320962e953f436cc81df9a1913841a1500928552L183-R185))

### New test cases for skipped landmarks:
* Added `test_process_landmarks_parallel_skips_zero_articles` to verify that landmarks with zero articles processed are tracked as skipped in parallel processing. (`tests/unit/test_wikipedia_processing.py`, [tests/unit/test_wikipedia_processing.pyR319-R337](diffhunk://#diff-3556b1117061ee8fbe4b5040e57cf925a20242503d404c3af7e13cb5616f38d0R319-R337))
* Added `test_process_landmarks_sequential_skips_zero_articles` to verify that landmarks with zero articles processed are tracked as skipped in sequential processing. (`tests/unit/test_wikipedia_processing.py`, [tests/unit/test_wikipedia_processing.pyR462-R475](diffhunk://#diff-3556b1117061ee8fbe4b5040e57cf925a20242503d404c3af7e13cb5616f38d0R462-R475))## Summary
- track skipped landmarks in parallel processing when `articles_processed == 0`
- cover skipped-landmark logic in unit tests for both parallel and sequential modes

## Testing
- `pytest tests/unit -q`

------
https://chatgpt.com/codex/tasks/task_e_68446c77be94832fac5daba6871b0c01