### PR TITLE
Remove redundant CLI validation

### DIFF
--- a/scripts/ci/process_landmarks.py
+++ b/scripts/ci/process_landmarks.py
@@ -1040,7 +1040,8 @@ def parse_arguments() -> argparse.Namespace:
         help="CoreDataStore API key (optional, uses env var if not set)",
     )
 
-    # Create mutually exclusive group for processing mode
+    # Create mutually exclusive group for processing mode. This group enforces
+    # that --all and --page cannot be used together.
     mode_group = parser.add_mutually_exclusive_group()
     mode_group.add_argument(
         "--all",
@@ -1062,12 +1063,6 @@ def parse_arguments() -> argparse.Namespace:
     )
 
     args = parser.parse_args()
-
-    # Additional validation: if someone uses --page with default value and --all
-    if args.all and args.page != 1:
-        parser.error(
-            "Argument --all cannot be used with --page (use either --all or --page N, not both)"
-        )
 
     return args
 

--- a/scripts/ci/process_wikipedia_articles.py
+++ b/scripts/ci/process_wikipedia_articles.py
@@ -241,7 +241,8 @@ def parse_arguments() -> argparse.Namespace:
         help="Number of landmarks to fetch per API request",
     )
 
-    # Create mutually exclusive group for processing mode
+    # Create mutually exclusive group for processing mode. This group enforces
+    # that --all and --page cannot be used together.
     mode_group = parser.add_mutually_exclusive_group()
     mode_group.add_argument(
         "--all",
@@ -263,10 +264,6 @@ def parse_arguments() -> argparse.Namespace:
     )
 
     args = parser.parse_args()
-
-    # Additional validation
-    if args.all and args.page != 1:
-        parser.error("Cannot use --all with --page (they are mutually exclusive)")
 
     return args
 


### PR DESCRIPTION
This pull request refactors argument parsing logic in two scripts, `process_landmarks.py` and `process_wikipedia_articles.py`, by improving the use of mutually exclusive argument groups and removing redundant manual validation.

### Improvements to argument parsing:

* `scripts/ci/process_landmarks.py`:
  - Enhanced the comment for the mutually exclusive group to clarify that `--all` and `--page` cannot be used together.
  - Removed redundant manual validation for the mutually exclusive arguments `--all` and `--page`, as this is now enforced by the argument group itself.

* `scripts/ci/process_wikipedia_articles.py`:
  - Updated the comment for the mutually exclusive group to explicitly state that `--all` and `--page` are mutually exclusive.
  - Removed redundant manual validation for the mutually exclusive arguments `--all` and `--page`, as this is now handled by the argument group.## Summary
- clean up `parse_arguments` helpers by deleting duplicate validation logic
- note in comments that the mutually exclusive group ensures `--all` and `--page` are exclusive

## Testing
- `python -m py_compile scripts/ci/process_landmarks.py scripts/ci/process_wikipedia_articles.py`

------
https://chatgpt.com/codex/tasks/task_e_6844742faa30832fa34ea408807d1a8b