### PR TITLE
Refactor process_single_landmark return tuple

### DIFF
--- a/scripts/ci/process_wikipedia_articles.py
+++ b/scripts/ci/process_wikipedia_articles.py
@@ -146,15 +146,15 @@ def process_landmarks_parallel(
     errors: List[str] = []
     skipped_landmarks: Set[str] = set()
 
-    def process_single_landmark(landmark_id: str) -> Tuple[str, bool, int, int]:
-        """Process a single landmark and return results."""
+    def process_single_landmark(landmark_id: str) -> Tuple[bool, int, int]:
+        """Process a single landmark and return the processing results."""
         processor = _get_processor()
         success, articles_processed, chunks_embedded = (
             processor.process_landmark_wikipedia(
                 landmark_id, delete_existing=delete_existing
             )
         )
-        return landmark_id, success, articles_processed, chunks_embedded
+        return success, articles_processed, chunks_embedded
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
         # Submit all tasks
@@ -171,9 +171,7 @@ def process_landmarks_parallel(
         ):
             landmark_id = future_to_landmark[future]
             try:
-                returned_id, success, articles_processed, chunks_embedded = (
-                    future.result()
-                )
+                success, articles_processed, chunks_embedded = future.result()
                 results[landmark_id] = {
                     "success": success,
                     "articles_processed": articles_processed,


### PR DESCRIPTION
This pull request simplifies the `process_landmarks_parallel` function in the `scripts/ci/process_wikipedia_articles.py` file by removing the redundant `landmark_id` from the return value of the `process_single_landmark` function. This change reduces unnecessary data handling and improves code clarity.

### Code simplification:

* [`scripts/ci/process_wikipedia_articles.py`](diffhunk://#diff-79b6896dfc7b36e103e6e8d7320962e953f436cc81df9a1913841a1500928552L149-R157): Updated the `process_single_landmark` function to no longer return the `landmark_id` as part of its result. The updated return type is now `Tuple[bool, int, int]`, and the function's docstring was modified accordingly.
* [`scripts/ci/process_wikipedia_articles.py`](diffhunk://#diff-79b6896dfc7b36e103e6e8d7320962e953f436cc81df9a1913841a1500928552L174-R174): Adjusted the handling of `future.result()` in the `process_landmarks_parallel` function to reflect the new return type of `process_single_landmark`. The `landmark_id` is now directly retrieved from the `future_to_landmark` mapping.## Summary
- simplify `process_single_landmark` return value
- handle new tuple format when aggregating parallel results

## Testing
- `pre-commit run --files scripts/ci/process_wikipedia_articles.py tests/unit/test_wikipedia_processing.py` *(fails to complete: KeyboardInterrupt)*
- `pytest -q` *(fails: Pinecone configuration errors)*

------
https://chatgpt.com/codex/tasks/task_e_6844776b89bc832f92732ce758227bea