### PR TITLE
Add Terraform monitoring config

### DIFF
--- a/docs/terraform_monitoring_setup.md
+++ b/docs/terraform_monitoring_setup.md
@@ -1,0 +1,27 @@
+# Terraform Monitoring Setup
+
+This configuration provisions monitoring resources for the NYC Landmarks Vector DB project using the Google Cloud provider.
+
+## Usage
+
+1. Export the target project ID or pass it as a variable:
+   ```bash
+   export GCP_PROJECT_ID="your-gcp-project"
+   ```
+   or set `-var project_id=your-gcp-project` when applying.
+1. Ensure the service account running Terraform has permissions to manage log-based metrics and dashboards (`roles/logging.configWriter` and `roles/monitoring.editor`).
+1. Apply the configuration:
+   ```bash
+   cd infrastructure/terraform
+   terraform init
+   terraform apply
+   ```
+
+The module creates log-based metrics:
+
+- `nyc-landmarks-vector-db.requests`
+- `nyc-landmarks-vector-db.errors`
+- `nyc-landmarks-vector-db.latency`
+- `nyc-landmarks-vector-db.validation_warnings`
+
+A monitoring dashboard defined in `dashboard.json` will also be deployed.

--- a/infrastructure/create_api_dashboard.sh
+++ b/infrastructure/create_api_dashboard.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# DEPRECATED: Use Terraform in infrastructure/terraform instead.
 
 # Create the infrastructure directory if it doesn't exist
 mkdir -p infrastructure

--- a/infrastructure/terraform/dashboard.json
+++ b/infrastructure/terraform/dashboard.json
@@ -1,0 +1,171 @@
+{
+  "displayName": "API Monitoring Starter Dashboard",
+  "gridLayout": {
+    "columns": "2",
+    "widgets": [
+      {
+        "title": "Total Request Count",
+        "xyChart": {
+          "dataSets": [
+            {
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"logging.googleapis.com/user/${var.log_name_prefix}.requests\" resource.type=\"cloud_run_revision\"",
+                  "aggregation": {
+                    "perSeriesAligner": "ALIGN_SUM",
+                    "crossSeriesReducer": "REDUCE_SUM",
+                    "alignmentPeriod": "60s"
+                  }
+                },
+                "unitOverride": "1"
+              },
+              "plotType": "STACKED_BAR"
+            }
+          ],
+          "timeshiftDuration": "0s",
+          "yAxis": {
+            "label": "count",
+            "scale": "LINEAR"
+          }
+        }
+      },
+      {
+        "title": "Average Latency",
+        "scorecard": {
+          "timeSeriesQuery": {
+            "timeSeriesFilter": {
+              "filter": "metric.type=\"logging.googleapis.com/user/${var.log_name_prefix}.latency\" resource.type=\"cloud_run_revision\"",
+              "aggregation": {
+                "perSeriesAligner": "ALIGN_MEAN",
+                "crossSeriesReducer": "REDUCE_MEAN",
+                "alignmentPeriod": "60s"
+              }
+            },
+            "unitOverride": "ms"
+          },
+          "thresholds": []
+        }
+      },
+      {
+        "title": "Request Rate",
+        "xyChart": {
+          "dataSets": [
+            {
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"logging.googleapis.com/user/${var.log_name_prefix}.requests\" resource.type=\"cloud_run_revision\"",
+                  "aggregation": {
+                    "perSeriesAligner": "ALIGN_RATE",
+                    "crossSeriesReducer": "REDUCE_SUM",
+                    "alignmentPeriod": "60s"
+                  }
+                },
+                "unitOverride": "1/s"
+              },
+              "plotType": "LINE"
+            }
+          ],
+          "timeshiftDuration": "0s",
+          "yAxis": {
+            "label": "requests/s",
+            "scale": "LINEAR"
+          }
+        }
+      },
+      {
+        "title": "Error Rate (5xx)",
+        "xyChart": {
+          "dataSets": [
+            {
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"logging.googleapis.com/user/${var.log_name_prefix}.errors\" resource.type=\"cloud_run_revision\"",
+                  "aggregation": {
+                    "perSeriesAligner": "ALIGN_RATE",
+                    "crossSeriesReducer": "REDUCE_SUM",
+                    "alignmentPeriod": "60s"
+                  }
+                },
+                "unitOverride": "1/s"
+              },
+              "plotType": "LINE"
+            }
+          ],
+          "timeshiftDuration": "0s",
+          "yAxis": {
+            "label": "errors/s",
+            "scale": "LINEAR"
+          }
+        }
+      },
+      {
+        "title": "Request Latency (Avg and 95th Percentile)",
+        "xyChart": {
+          "dataSets": [
+            {
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"logging.googleapis.com/user/${var.log_name_prefix}.latency\" resource.type=\"cloud_run_revision\"",
+                  "aggregation": {
+                    "perSeriesAligner": "ALIGN_PERCENTILE_95",
+                    "crossSeriesReducer": "REDUCE_MAX",
+                    "alignmentPeriod": "60s"
+                  }
+                },
+                "unitOverride": "ms",
+                "plotType": "LINE"
+              },
+              "targetAxis": "Y1"
+            },
+            {
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"logging.googleapis.com/user/${var.log_name_prefix}.latency\" resource.type=\"cloud_run_revision\"",
+                  "aggregation": {
+                    "perSeriesAligner": "ALIGN_MEAN",
+                    "crossSeriesReducer": "REDUCE_MEAN",
+                    "alignmentPeriod": "60s"
+                  }
+                },
+                "unitOverride": "ms",
+                "plotType": "LINE"
+              },
+              "targetAxis": "Y1"
+            }
+          ],
+          "timeshiftDuration": "0s",
+          "yAxis": {
+            "label": "ms",
+            "scale": "LINEAR"
+          }
+        }
+      },
+      {
+        "title": "Validation Warning Rate",
+        "xyChart": {
+          "dataSets": [
+            {
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"logging.googleapis.com/user/${var.log_name_prefix}.validation_warnings\" resource.type=\"cloud_run_revision\"",
+                  "aggregation": {
+                    "perSeriesAligner": "ALIGN_RATE",
+                    "crossSeriesReducer": "REDUCE_SUM",
+                    "alignmentPeriod": "60s"
+                  }
+                },
+                "unitOverride": "1/s"
+              },
+              "plotType": "LINE"
+            }
+          ],
+          "timeshiftDuration": "0s",
+          "yAxis": {
+            "label": "warnings/s",
+            "scale": "LINEAR"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -1,0 +1,31 @@
+locals {
+  project_id = var.project_id != "" ? var.project_id : env("GCP_PROJECT_ID")
+}
+
+provider "google" {
+  project = local.project_id
+}
+
+resource "google_logging_metric" "requests" {
+  name   = "${var.log_name_prefix}.requests"
+  filter = "resource.type=\"cloud_run_revision\" AND logName=\"projects/${local.project_id}/logs/${var.log_name_prefix}.nyc_landmarks.api.middleware\" AND jsonPayload.metric_type=\"performance\""
+}
+
+resource "google_logging_metric" "errors" {
+  name   = "${var.log_name_prefix}.errors"
+  filter = "resource.type=\"cloud_run_revision\" AND logName=\"projects/${local.project_id}/logs/${var.log_name_prefix}.nyc_landmarks.api.middleware\" AND jsonPayload.metric_type=\"performance\" AND jsonPayload.status_code>=500"
+}
+
+resource "google_logging_metric" "latency" {
+  name   = "${var.log_name_prefix}.latency"
+  filter = "resource.type=\"cloud_run_revision\" AND logName=\"projects/${local.project_id}/logs/${var.log_name_prefix}.nyc_landmarks.api.middleware\" AND jsonPayload.metric_type=\"performance\" AND jsonPayload.duration_ms>=0"
+}
+
+resource "google_logging_metric" "validation_warnings" {
+  name   = "${var.log_name_prefix}.validation_warnings"
+  filter = "resource.type=\"cloud_run_revision\" AND logName=\"projects/${local.project_id}/logs/${var.log_name_prefix}.nyc_landmarks.utils.validation\" AND severity=\"WARNING\""
+}
+
+resource "google_monitoring_dashboard" "api_dashboard" {
+  dashboard_json = file("${path.module}/dashboard.json")
+}

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -1,0 +1,11 @@
+variable "project_id" {
+  type        = string
+  description = "GCP project ID"
+  default     = ""
+}
+
+variable "log_name_prefix" {
+  type        = string
+  description = "Prefix for application logs"
+  default     = "nyc-landmarks-vector-db"
+}


### PR DESCRIPTION
## Summary
- deprecate `create_api_dashboard.sh`
- add Terraform configuration for log metrics and dashboard
- document how to apply Terraform setup

## Testing
- `pre-commit run --files infrastructure/terraform/main.tf infrastructure/terraform/variables.tf infrastructure/terraform/dashboard.json docs/terraform_monitoring_setup.md infrastructure/create_api_dashboard.sh`
- `pytest` *(fails: PineconeConfigurationError)*

------
https://chatgpt.com/codex/tasks/task_e_6845ca14acb8832f98ef873c468b41e0