### PR TITLE
Fix Swagger

### DIFF
--- a/nyc_landmarks/examples/search_examples.py
+++ b/nyc_landmarks/examples/search_examples.py
@@ -107,5 +107,35 @@ def get_landmark_filter_examples() -> Dict[str, Dict[str, Any]]:
                 "source_type": None,
                 "top_k": 5,
             },
-        }
+        },
+        "empire_state_building_specific": {
+            "summary": "Empire State Building History (Landmark-Specific)",
+            "description": "Search for historical information about the Empire State Building specifically",
+            "value": {
+                "query": "Tell me about the history of this landmark",
+                "landmark_id": "LP-02000",  # Empire State Building
+                "source_type": "pdf",
+                "top_k": 8,
+            },
+        },
+        "architectural_style_specific": {
+            "summary": "Architectural Style of Specific Landmark",
+            "description": "Search for architectural style information about a specific landmark",
+            "value": {
+                "query": "What architectural style is this building?",
+                "landmark_id": "LP-01234",  # Example landmark ID
+                "source_type": None,
+                "top_k": 3,
+            },
+        },
+        "designation_history_specific": {
+            "summary": "Designation History of Specific Landmark",
+            "description": "Search for designation and preservation history of a specific landmark",
+            "value": {
+                "query": "When was this landmark designated and why?",
+                "landmark_id": "LP-00500",  # Example landmark ID
+                "source_type": "pdf",
+                "top_k": 5,
+            },
+        },
     }


### PR DESCRIPTION
This pull request introduces enhancements to the NYC Landmarks API to improve usability and documentation, particularly in the Swagger UI. The changes include adding structured examples for API endpoints, refactoring the handling of request bodies, and expanding the set of landmark-specific search examples.

### Enhancements to Swagger UI and API Documentation:

* [`nyc_landmarks/api/query.py`](diffhunk://#diff-7dd247b08de71de430a20665fe13c05d57fb74436c23c811ba40ba678ecdd960R114-R130): Added `_convert_to_fastapi_examples` helper function to convert structured examples into FastAPI's `Example` format for better Swagger UI dropdown support.
* [`nyc_landmarks/api/query.py`](diffhunk://#diff-7dd247b08de71de430a20665fe13c05d57fb74436c23c811ba40ba678ecdd960L139-R162): Updated `search_text` and `search_text_by_landmark` endpoints to use `Body` with `openapi_examples`, replacing the previous inline `responses` definitions. This improves the clarity and organization of example data in Swagger UI. [[1]](diffhunk://#diff-7dd247b08de71de430a20665fe13c05d57fb74436c23c811ba40ba678ecdd960L139-R162) [[2]](diffhunk://#diff-7dd247b08de71de430a20665fe13c05d57fb74436c23c811ba40ba678ecdd960L292-R312)

### Expanded Landmark-Specific Examples:

* [`nyc_landmarks/examples/search_examples.py`](diffhunk://#diff-a2e8f3b058723dad8643241ae57298795714f06bdf50eb7b0eeae50846890b28L110-R140): Added new landmark-specific examples, such as "Empire State Building History," "Architectural Style," and "Designation History," to enrich the API's example set for targeted queries.

### Minor Refactoring:

* [`nyc_landmarks/api/query.py`](diffhunk://#diff-7dd247b08de71de430a20665fe13c05d57fb74436c23c811ba40ba678ecdd960L331-R340): Adjusted the `search_text_by_landmark` function call to reorder arguments for consistency with updated endpoint definitions.