### PR TITLE
Add vectordb log metric

### DIFF
--- a/docs/terraform_monitoring_setup.md
+++ b/docs/terraform_monitoring_setup.md
@@ -70,6 +70,11 @@ The module creates log-based metrics:
 - `{log_name_prefix}.errors` - HTTP 5xx errors
 - `{log_name_prefix}.latency` - Request duration
 - `{log_name_prefix}.validation_warnings` - Validation warnings
+- `{log_name_prefix}.vectordb_logs` - Vector database log count
+
+The configuration also creates a dedicated log bucket and view named
+`vectordb-view` to surface vector database logs in the Cloud Console.
+You can access it from **Logs Explorer** under the bucket `vectordb-logs`.
 
 A comprehensive monitoring dashboard with widgets for:
 
@@ -77,6 +82,21 @@ A comprehensive monitoring dashboard with widgets for:
 - Error rate
 - Latency (average and 95th percentile)
 - Validation warning rate
+
+### Log Explorer Queries for Vector DB Logs
+
+To view logs captured by the `vectordb_logs` metric, open **Logs Explorer** and
+run queries such as:
+
+```text
+logName=~"${LOG_NAME_PREFIX}.nyc_landmarks.vectordb"
+```
+
+Or filter using the dedicated view:
+
+```text
+resource.type="logging_bucket" AND resource.labels.bucket_name="vectordb-logs"
+```
 
 ## Scripts
 

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -41,6 +41,26 @@ resource "google_logging_metric" "validation_warnings" {
   filter = "resource.type=\"cloud_run_revision\" AND logName=\"projects/${local.project_id}/logs/${var.log_name_prefix}.nyc_landmarks.utils.validation\" AND severity=\"WARNING\""
 }
 
+resource "google_logging_metric" "vectordb_logs" {
+  name   = "${var.log_name_prefix}.vectordb_logs"
+  filter = "logName=~\"${var.log_name_prefix}.nyc_landmarks.vectordb\""
+}
+
+resource "google_logging_project_bucket_config" "vectordb_logs_bucket" {
+  project        = local.project_id
+  location       = "global"
+  bucket_id      = "vectordb-logs"
+  retention_days = 30
+}
+
+resource "google_logging_view" "vectordb_logs_view" {
+  project  = google_logging_project_bucket_config.vectordb_logs_bucket.project
+  location = google_logging_project_bucket_config.vectordb_logs_bucket.location
+  bucket   = google_logging_project_bucket_config.vectordb_logs_bucket.bucket_id
+  view_id  = "vectordb-view"
+  filter   = google_logging_metric.vectordb_logs.filter
+}
+
 # Uptime check for the health endpoint
 resource "google_monitoring_uptime_check_config" "health_check" {
   display_name = "NYC Landmarks Vector DB Health Check"

--- a/infrastructure/terraform/outputs.tf
+++ b/infrastructure/terraform/outputs.tf
@@ -15,6 +15,7 @@ output "log_metrics" {
     errors              = google_logging_metric.errors.name
     latency             = google_logging_metric.latency.name
     validation_warnings = google_logging_metric.validation_warnings.name
+    vectordb_logs       = google_logging_metric.vectordb_logs.name
   }
 }
 
@@ -41,4 +42,9 @@ output "uptime_check_id" {
 output "uptime_check_name" {
   description = "The uptime check display name"
   value       = google_monitoring_uptime_check_config.health_check.display_name
+}
+
+output "vectordb_view_name" {
+  description = "Logging view for vectordb logs"
+  value       = google_logging_view.vectordb_logs_view.name
 }


### PR DESCRIPTION
## Summary
- create vectordb log-based metric, bucket, and view
- expose vectordb metric and view outputs
- document monitoring setup with queries

## Testing
- `pre-commit run --files docs/terraform_monitoring_setup.md infrastructure/terraform/main.tf infrastructure/terraform/outputs.tf` *(failed: Failed to query available provider packages)*
- `pytest -q` *(failed: blocked network access during tests)*

------
https://chatgpt.com/codex/tasks/task_e_68544f99a5e0832fbdddeafd9b8d3f61