### PR TITLE
Fix: Trigger fresh Terraform run after deleting manual sinks

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -107,6 +107,7 @@ resource "google_logging_log_view" "api_health_logs_view" {
 }
 
 # Log Sink for API Logs
+# Note: Manual sinks were deleted to allow Terraform to manage them properly
 resource "google_logging_project_sink" "api_logs_sink" {
   name        = "api-logs-sink"
   destination = "logging.googleapis.com/${google_logging_project_bucket_config.api_logs_bucket.id}"


### PR DESCRIPTION
## Problem
The previous Terraform Cloud run failed because it was trying to import manually created log sinks that had incompatible writer identity formats.

## Solution
1. Deleted the manually created log sinks ( and )
2. Added a comment to trigger a fresh Terraform run
3. Now Terraform can create the sinks from scratch with proper writer identities

## Expected Result
- Log sinks will be created by Terraform with proper writer identities
- IAM permissions will be granted correctly
- Endpoint-specific log views will be created:
  -  logs view
  -  logs view  
  -  logs view

This should resolve the IAM member validation error.